### PR TITLE
Fix logo display sizing

### DIFF
--- a/src/Modules/Homepage/Components/TimeLine.js
+++ b/src/Modules/Homepage/Components/TimeLine.js
@@ -43,7 +43,12 @@ function TimeLine(props){
                   <img
                     src={process.env.PUBLIC_URL + `/${imagePath}`}
                     alt="CompanyLogo"
-                    style={{ height: "50px" }}
+                    style={{ 
+                      height: "50px", 
+                      width: "auto", 
+                      maxWidth: "150px",
+                      objectFit: "contain" 
+                    }}
                   />
                 </div>}
               </div>


### PR DESCRIPTION
Improve logo display in timeline with proper sizing:
- Added maxWidth and objectFit for better logo display
- Fixed horizontal text-based logos from appearing stretched